### PR TITLE
Fixed quitting to menu breaking the scene loading

### DIFF
--- a/Assets/GameManager/Prefabs/GameManager.prefab
+++ b/Assets/GameManager/Prefabs/GameManager.prefab
@@ -44,9 +44,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ee67195f91790cc4dbab4e502ff2c450, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_gameState: 2
-  m_currentLevel: 0
-  m_levels: []
-  m_levelManager: {fileID: 0}
-  m_freeLookCam: {fileID: 0}
+  m_gameState: 0
   m_pauseMenu: {fileID: 0}

--- a/Assets/Menus/Scripts/MainMenu.cs
+++ b/Assets/Menus/Scripts/MainMenu.cs
@@ -7,6 +7,7 @@
 
 using Millivolt.UI;
 using Pixelplacement;
+using System.Collections;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UI;
@@ -26,12 +27,24 @@ namespace Millivolt
         [Header("Level Select")]
         [SerializeField] private GameObject m_levelSelector;
         [SerializeField] private Button[] m_levelButtons;
+        [SerializeField] private float m_levelLoadDelay = 0.5f;
 
         private void Start()
         {
             UIMenu menu = GetComponent<UIMenu>();
             menu.ActivateMenu();
             SetActiveButton(m_selectedButton);
+        }
+
+        public void LoadFromLevelSelect(string levelName)
+        {
+            StartCoroutine(LoadLevelOnDelay(levelName));
+        }
+
+        private IEnumerator LoadLevelOnDelay(string levelName)
+        {
+            yield return new WaitForSecondsRealtime(m_levelLoadDelay);
+            GameManager.Instance.LoadLevel(levelName);
         }
 
         public void SetActiveButton(int index)

--- a/Assets/_Scenes/MenuScene.unity
+++ b/Assets/_Scenes/MenuScene.unity
@@ -606,201 +606,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1001 &306146815
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 483975511}
-    m_Modifications:
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521555, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_Name
-      value: Microwave (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521556, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 1254258114}
-    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 638667629}
-    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
-      value: 
-      objectReference: {fileID: 5383357392527668389}
-    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: LoadLevel
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: SetActive
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: Millivolt.GameManager, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
-      value: UnityEngine.GameObject, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_BoolArgument
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
-      value: '[NewMicrowaveLevel]'
-      objectReference: {fileID: 0}
-    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 059808da86fd3304aac1d1616a4ae78c, type: 3}
---- !u!224 &306146816 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
-    type: 3}
-  m_PrefabInstance: {fileID: 306146815}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &329330650
 GameObject:
   m_ObjectHideFlags: 0
@@ -907,7 +712,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 96427747}
-  - {fileID: 306146816}
+  - {fileID: 533561544}
   m_Father: {fileID: 605059253}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1233,6 +1038,261 @@ MonoBehaviour:
   m_RequiresDepthTexture: 0
   m_RequiresColorTexture: 0
   m_Version: 2
+--- !u!1001 &533561543
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 483975511}
+    m_Modifications:
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521555, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_Name
+      value: Microwave (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521556, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521556, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521556, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521556, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1254258114}
+    - target: {fileID: 1139293060772521556, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521556, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: EnableMainMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521556, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: Millivolt.MainMenu, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521556, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: Millivolt.MainMenu, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521556, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
+      value: MenuScene
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1254258114}
+    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 5383357392527668389}
+    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: LoadFromLevelSelect
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: SetActive
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: Millivolt.MainMenu, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_BoolArgument
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
+      value: MicrowaveScene
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293061479216354, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293061479216354, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293061479216354, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139293061479216354, guid: 059808da86fd3304aac1d1616a4ae78c,
+        type: 3}
+      propertyPath: m_UVRect.x
+      value: 0.42
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 059808da86fd3304aac1d1616a4ae78c, type: 3}
+--- !u!224 &533561544 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1139293060772521554, guid: 059808da86fd3304aac1d1616a4ae78c,
+    type: 3}
+  m_PrefabInstance: {fileID: 533561543}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &605059252
 GameObject:
   m_ObjectHideFlags: 0
@@ -1396,18 +1456,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 297b579e2b9899742a58b62cde755d2b, type: 3}
---- !u!114 &638667629 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8747714931351379655, guid: 297b579e2b9899742a58b62cde755d2b,
-    type: 3}
-  m_PrefabInstance: {fileID: 638667628}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ee67195f91790cc4dbab4e502ff2c450, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &692597967
 GameObject:
   m_ObjectHideFlags: 0
@@ -2603,18 +2651,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_selectIcon: {fileID: 1795585759}
   m_buttonObj: {fileID: 0}
---- !u!114 &1184613271 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
-    type: 3}
-  m_PrefabInstance: {fileID: 306146815}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1193936631
 GameObject:
   m_ObjectHideFlags: 0
@@ -2906,7 +2942,7 @@ MonoBehaviour:
   m_levelSelector: {fileID: 526705283}
   m_levelButtons:
   - {fileID: 96427748}
-  - {fileID: 1184613271}
+  - {fileID: 0}
 --- !u!1 &1356500751
 GameObject:
   m_ObjectHideFlags: 0
@@ -4239,7 +4275,7 @@ MonoBehaviour:
     m_ActionName: UI/TrackedDeviceOrientation
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: Keyboard&Mouse
-  m_DefaultActionMap: 740d1ddb-d2e3-4cf4-92e4-7d7b49752459
+  m_DefaultActionMap: UI
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 528988632}
 --- !u!4 &1759777386
@@ -5129,7 +5165,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 638667629}
+      objectReference: {fileID: 1254258114}
     - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
@@ -5143,7 +5179,7 @@ PrefabInstance:
     - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: LoadLevel
+      value: LoadFromLevelSelect
       objectReference: {fileID: 0}
     - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
         type: 3}
@@ -5153,7 +5189,7 @@ PrefabInstance:
     - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: Millivolt.GameManager, Assembly-CSharp
+      value: Millivolt.MainMenu, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 1139293060772521557, guid: 059808da86fd3304aac1d1616a4ae78c,
         type: 3}


### PR DESCRIPTION
Issue was a missing GameManager reference since it stays in destroy on load after the game is opened, removing the reference when re-opening the scene. Now calls a method on the MainMenu script that calls the original GameManager method through its static instance on a delay so that the CRT effect still plays (it was getting eaten during the scene loading). Also made the default state of the GameManager to be MENU instead of PLAYING.