### PR TITLE
Complex player Can Move

### DIFF
--- a/Assets/LevelObjects/EventObjects/Scripts/LaunchPad.cs
+++ b/Assets/LevelObjects/EventObjects/Scripts/LaunchPad.cs
@@ -40,7 +40,7 @@ namespace Millivolt
                         if (GameManager.PlayerController.gameObject == m_objectToLaunch.gameObject)
                         {
                             GameManager.PlayerController.SetExternalVelocity(m_initialVelocity);
-                            GameManager.PlayerController.canMove = false;
+                            GameManager.PlayerController.SetCanMove(false, Player.CanMoveType.LevelObject);
                         }
                         else
                             m_objectToLaunch.velocity = m_initialVelocity;

--- a/Assets/LevelObjects/PickupObjects/Scripts/PlantableScrew.cs
+++ b/Assets/LevelObjects/PickupObjects/Scripts/PlantableScrew.cs
@@ -22,7 +22,7 @@ namespace Millivolt
 
 				private void Plant()
 				{
-					GameManager.PlayerController.canMove = !m_inUse;
+					GameManager.PlayerController.SetCanMove(!m_inUse, Player.CanMoveType.HeldObject);
 				}
             }
 		}

--- a/Assets/Player/Scripts/PlayerCanMove.cs
+++ b/Assets/Player/Scripts/PlayerCanMove.cs
@@ -1,0 +1,58 @@
+///<summary>
+/// Author: Halen
+///
+/// Holds the class for the complex Player 'can move' check.
+///
+///</summary>
+
+using UnityEngine;
+
+namespace Millivolt
+{
+    namespace Player
+    {
+        public enum CanMoveType
+        {
+            LevelObject,
+            Cutscene,
+            Gravity,
+            Dead,
+            Menu,
+            HeldObject,
+            COUNT
+        }
+
+        public class PlayerCanMove
+        {
+            public PlayerCanMove()
+            {
+                m_canMoves = new bool[(int)CanMoveType.COUNT];
+
+                for (int c = 0; c < (int)CanMoveType.COUNT; c++)
+                {
+                    m_canMoves[c] = false;
+                }
+            }
+
+            private bool[] m_canMoves;
+
+            public bool canMove
+            {
+                get
+                {
+                    for (int c = 0; c < (int)CanMoveType.COUNT; c++)
+                    {
+                        if (m_canMoves[c])
+                            return false;
+                    }
+                    return true;
+                }
+            }
+
+            public void SetCanMove(bool value, CanMoveType type)
+            {
+                m_canMoves[(int)type] = !value;
+            }
+        }
+    }
+}

--- a/Assets/Player/Scripts/PlayerCanMove.cs.meta
+++ b/Assets/Player/Scripts/PlayerCanMove.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13dc868b8e24c95458be25f6eba975b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Player/Scripts/PlayerController.cs
+++ b/Assets/Player/Scripts/PlayerController.cs
@@ -16,6 +16,11 @@ namespace Millivolt
         [RequireComponent(typeof(Rigidbody), typeof(PlayerInput))]
         public class PlayerController : MonoBehaviour
         {
+            private void Start()
+            {
+                m_canMove = new PlayerCanMove();
+            }
+
             private void FixedUpdate()
             {
                 MovePlayer();
@@ -43,6 +48,13 @@ namespace Millivolt
                 }
             }
 
+            private PlayerCanMove m_canMove;
+            public bool canMove { get { return m_canMove.canMove; } }
+            public void SetCanMove(bool value, CanMoveType type)
+            {
+                m_canMove.SetCanMove(value, type);
+            }
+
             [Header("Physics")]
             [Tooltip("The layers of objects that the CharacterController can interact with.")]
             [SerializeField] private LayerMask m_walkableLayers;
@@ -57,7 +69,6 @@ namespace Millivolt
                     return m_rb;
                 }
             }
-
             new public CapsuleCollider collider { get { return model.collider; } }
 
             [ContextMenu("Initialise GameManager.PlayerModel/Collider")]
@@ -85,8 +96,6 @@ namespace Millivolt
             [SerializeField] private float m_acceleration;
             [SerializeField] private float m_decceleration;
             [SerializeField, Range(0, 90)] private float m_slopeLimit;
-
-            public bool canMove = true;
 
             private Vector2 m_moveInput;
             private Vector3 m_walkVelocity;
@@ -267,7 +276,7 @@ namespace Millivolt
                             if (m_externalVelocity != Vector3.zero)
                             {
                                 m_externalVelocity = Vector3.zero;
-                                canMove = true;
+                                SetCanMove(true, CanMoveType.LevelObject);
                             }
                         }
 

--- a/Assets/Player/Scripts/PlayerModel.cs
+++ b/Assets/Player/Scripts/PlayerModel.cs
@@ -72,7 +72,7 @@ namespace Millivolt
 
             private IEnumerator RotateWithGravity(Quaternion targetAngle)
             {
-                GameManager.PlayerController.canMove = false;
+                GameManager.PlayerController.SetCanMove(false, CanMoveType.Gravity);
 
                 //transform.rotation = transform.localRotation;
                 Quaternion startAngle = transform.rotation;
@@ -86,7 +86,7 @@ namespace Millivolt
                     yield return new WaitForEndOfFrame();
                 }
 
-                GameManager.PlayerController.canMove = true;
+                GameManager.PlayerController.SetCanMove(true, CanMoveType.Gravity);
             }
 
             public void ResetRotation()

--- a/Assets/Player/Scripts/PlayerStatus.cs
+++ b/Assets/Player/Scripts/PlayerStatus.cs
@@ -108,7 +108,7 @@ namespace Millivolt
                 m_currentHealth = m_maxHealth;
                 UpdateVignetteEffect();
                 m_deathCanvas.SetActive(true);
-                GameManager.PlayerController.canMove = false;
+                GameManager.PlayerController.SetCanMove(false, CanMoveType.Dead);
                 m_spawnScreenEffect.SetActive(true);
                 LevelManager.Instance.Invoke(nameof(LevelManager.Instance.SpawnPlayer), m_respawnTime);
             }

--- a/Assets/Player/UI/Scripts/PlayerSpawnUI.cs
+++ b/Assets/Player/UI/Scripts/PlayerSpawnUI.cs
@@ -11,21 +11,15 @@ using Pixelplacement;
 
 namespace Millivolt
 {
-	using UI;
-
-	namespace Player
-	{
-		namespace UI
-		{
-			public class PlayerSpawnUI : ScreenFadeEffect
-			{
-
-                protected override void DisableThis()
-                {
-                    base.DisableThis();
-                    GameManager.PlayerController.canMove = true;
-                }
+    namespace UI
+    {
+        public class PlayerSpawnUI : ScreenFadeEffect
+        {
+            protected override void DisableThis()
+            {
+                base.DisableThis();
+                GameManager.PlayerController.SetCanMove(true, Player.CanMoveType.Dead);
             }
-		}
-	}
+        }
+    }
 }


### PR DESCRIPTION
Complex checking and setting for when the player can move. Many cases to stop different systems from stepping on each other's toes, such as not moving when being launched by a launchpad versus not moving while dead.