### PR TITLE
Cinemachine Cutscene setup

### DIFF
--- a/Assets/Camera/Camera Blends.asset
+++ b/Assets/Camera/Camera Blends.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36baaa8bdcb9d8b49b9199833965d2c3, type: 3}
+  m_Name: Camera Blends
+  m_EditorClassIdentifier: 
+  m_CustomBlends: []

--- a/Assets/Camera/Camera Blends.asset.meta
+++ b/Assets/Camera/Camera Blends.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d30cc686cf32f254984cd4a738e15958
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Camera/Prefabs/Cutscene Camera.prefab
+++ b/Assets/Camera/Prefabs/Cutscene Camera.prefab
@@ -1,0 +1,182 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2005009926897033321
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2005009926897033324}
+  - component: {fileID: 2005009926897033323}
+  - component: {fileID: 2005009926897033322}
+  m_Layer: 0
+  m_Name: Cutscene Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2005009926897033324
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2005009926897033321}
+  m_LocalRotation: {x: 0.09922881, y: 0.43517426, z: -0.04649148, w: 0.893653}
+  m_LocalPosition: {x: -3.7941828, y: 1.3469434, z: -5.044408}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2005009926934023080}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2005009926897033323
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2005009926897033321}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0946110856ba7a4facc5cc1aade1827, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_duration: 3
+--- !u!114 &2005009926897033322
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2005009926897033321}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 9
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_Lens:
+    FieldOfView: 60
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    m_SensorSize: {x: 1, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 2005009926934023080}
+--- !u!1 &2005009926934023095
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2005009926934023080}
+  - component: {fileID: 2005009926934023083}
+  - component: {fileID: 2005009926934023082}
+  - component: {fileID: 2005009926934023081}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2005009926934023080
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2005009926934023095}
+  m_LocalRotation: {x: -0.09922881, y: -0.43517426, z: 0.04649148, w: 0.893653}
+  m_LocalPosition: {x: -1.6337118, y: 0.018880606, z: 6.2439375}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2005009926897033324}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2005009926934023083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2005009926934023095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2005009926934023082
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2005009926934023095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0.5
+  m_VerticalDamping: 0.5
+  m_ScreenX: 0.5
+  m_ScreenY: 0.5
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &2005009926934023081
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2005009926934023095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fa7155796051b734daa718462081dc5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BindingMode: 1
+  m_FollowOffset: {x: 0, y: 0, z: -10}
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_AngularDampingMode: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AngularDamping: 0

--- a/Assets/Camera/Prefabs/Cutscene Camera.prefab.meta
+++ b/Assets/Camera/Prefabs/Cutscene Camera.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2d52c67758bf0bb40bf7446a86effca6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Camera/Scripts/CutsceneCamera.cs
+++ b/Assets/Camera/Scripts/CutsceneCamera.cs
@@ -1,0 +1,45 @@
+///<summary>
+/// Author: Halen
+///
+/// Component to handle behaviour for how and when cutscenes are played.
+///
+///</summary>
+
+using Cinemachine;
+using System.Collections;
+using UnityEngine;
+
+namespace Millivolt
+{
+    namespace Cutscene
+    {
+        [RequireComponent(typeof(CinemachineVirtualCamera))]
+        public class CutsceneCamera : MonoBehaviour
+        {
+            [SerializeField, Min(0)] private float m_duration;
+
+            private CinemachineVirtualCamera m_vcam;
+
+            private void Start()
+            {
+                m_vcam = GetComponent<CinemachineVirtualCamera>();
+            }
+
+            public void StartCutscene()
+            {
+                StartCoroutine(Play());
+            }
+
+            private IEnumerator Play()
+            {
+                GameManager.PlayerController.SetCanMove(false, Player.CanMoveType.Cutscene);
+
+                m_vcam.Priority += 10;
+                yield return new WaitForSecondsRealtime(m_duration);
+                m_vcam.Priority -= 10;
+
+                GameManager.PlayerController.SetCanMove(true, Player.CanMoveType.Cutscene);
+            }
+        }
+    }
+}

--- a/Assets/Camera/Scripts/CutsceneCamera.cs.meta
+++ b/Assets/Camera/Scripts/CutsceneCamera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0946110856ba7a4facc5cc1aade1827
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Created script to handle using cinemachine to make little cutscenes for puzzles. Simply increases the priority of the desired camera and takes away control from the player for the desired duration. Created a Cinemachine Blend asset to specify transitions between cutscene cameras.