### PR TITLE
Changed the canvas sort order

### DIFF
--- a/Assets/Player/UI/Prefabs/DeathCanvas.prefab
+++ b/Assets/Player/UI/Prefabs/DeathCanvas.prefab
@@ -137,7 +137,7 @@ Canvas:
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 10
   m_TargetDisplay: 0
 --- !u!114 &5383357393564954141
 MonoBehaviour:

--- a/Assets/Player/UI/Prefabs/PlayerSpawnUI.prefab
+++ b/Assets/Player/UI/Prefabs/PlayerSpawnUI.prefab
@@ -61,7 +61,7 @@ Canvas:
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 7
   m_TargetDisplay: 0
 --- !u!114 &2899301961285802364
 MonoBehaviour:


### PR DESCRIPTION
The canvas's for the death and spawn screen effects are not sorted correctly so that they wont cover each other and now show now