### PR TITLE
Fixed sensitivity settings not working

### DIFF
--- a/Assets/Camera/Scripts/CameraController.cs
+++ b/Assets/Camera/Scripts/CameraController.cs
@@ -97,6 +97,9 @@ namespace Millivolt
 
             public void UpdateSensitivity(float h, float v)
             {
+                horizontalSensitivity = h;
+                verticalSensitivity = v;
+
                 m_normalPOV.m_HorizontalAxis.m_MaxSpeed = horizontalSensitivity;
                 m_normalPOV.m_VerticalAxis.m_MaxSpeed = verticalSensitivity;
 


### PR DESCRIPTION
Updated camera controller so that it will change the sensitivity of the camera. TODO: Store this value in the GameManager probably, so that you can change it in the main menu