### PR TITLE
small fixes

### DIFF
--- a/Assets/Levels/Microwave/AnimatedObjectsFolder/ScrewSocket/ANIMATION/ScrewSocketA.controller
+++ b/Assets/Levels/Microwave/AnimatedObjectsFolder/ScrewSocket/ANIMATION/ScrewSocketA.controller
@@ -22,28 +22,6 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!1101 &-5268811204975983956
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions: []
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 1178417887545401671}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0.012862689
-  m_ExitTime: 0.9995866
-  m_HasExitTime: 0
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -118,28 +96,6 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1101 &5664813038415695473
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions: []
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 8073998056764235948}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0.0032321631
-  m_ExitTime: 0.9941922
-  m_HasExitTime: 0
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
 --- !u!1102 &5939476420391280015
 AnimatorState:
   serializedVersion: 6
@@ -177,7 +133,7 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: 1178417887545401671}
-    m_Position: {x: 310, y: -30, z: 0}
+    m_Position: {x: 310, y: -20, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 8073998056764235948}
     m_Position: {x: 310, y: 50, z: 0}
@@ -188,9 +144,7 @@ AnimatorStateMachine:
     m_State: {fileID: 5939476420391280015}
     m_Position: {x: 550, y: 50, z: 0}
   m_ChildStateMachines: []
-  m_AnyStateTransitions:
-  - {fileID: -5268811204975983956}
-  - {fileID: 5664813038415695473}
+  m_AnyStateTransitions: []
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []

--- a/Assets/Sound/Scripts/SoundClipObject.cs
+++ b/Assets/Sound/Scripts/SoundClipObject.cs
@@ -20,6 +20,9 @@ namespace Millivolt
 
         public void Init(SFXController.SoundClip soundClip, SoundType type)
         {
+            if (!m_source.enabled)
+                return;
+
             // get source component
             m_source = GetComponent<AudioSource>();
             m_source.clip = soundClip.audioClip;


### PR DESCRIPTION
setup Screw Socket A's animator to be in standard config. Added a check to the SoundClipObject that checks if the source attached to it is enabled before it attempts to play the sound.