### PR TITLE
Camera stops on pause and interact on controller changed

### DIFF
--- a/Assets/Camera/Scripts/CameraController.cs
+++ b/Assets/Camera/Scripts/CameraController.cs
@@ -56,6 +56,9 @@ namespace Millivolt
 
             public void Update()
             {
+                //Set sensitivity to 0 if the game is paused
+                PauseCheck();
+
                 // calc target position of focus point
                 float targetScreenX = 0.5f - m_horizontalMoveDelta * m_screenXRange;
 
@@ -76,6 +79,20 @@ namespace Millivolt
                 {
                     m_highCamIsEnabled = false;
                     m_3rdPersonCam.Follow = m_normalTarget;
+                }
+            }
+
+            private void PauseCheck()
+            {
+                if (GameManager.Instance.gameState == GameState.PAUSE)
+                {
+                    m_camPOV.m_HorizontalAxis.m_MaxSpeed = 0;
+                    m_camPOV.m_VerticalAxis.m_MaxSpeed = 0;
+                }
+                else
+                {
+                    m_camPOV.m_HorizontalAxis.m_MaxSpeed = horizontalSensitivity;
+                    m_camPOV.m_VerticalAxis.m_MaxSpeed = verticalSensitivity;
                 }
             }
 

--- a/Assets/Input/MillivoltInputActions.inputactions
+++ b/Assets/Input/MillivoltInputActions.inputactions
@@ -185,18 +185,7 @@
                 {
                     "name": "",
                     "id": "f284e170-1726-4824-b47c-2ef3ae68c86a",
-                    "path": "<Gamepad>/leftShoulder",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "Gamepad",
-                    "action": "Interact",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "21f29b2f-f733-4aba-9e1d-58465b8b4954",
-                    "path": "<Gamepad>/leftTrigger",
+                    "path": "<Gamepad>/buttonWest",
                     "interactions": "",
                     "processors": "",
                     "groups": "Gamepad",


### PR DESCRIPTION
Camera controller will now stop when hitting the pause button. The controller input for interact has been changed to the west face button instead of the bumper. TODO, change the controller input icon before Supernova