### PR TITLE
Fixed options menu causing camera to move

### DIFF
--- a/Assets/Menus/Scripts/OptionMenu.cs
+++ b/Assets/Menus/Scripts/OptionMenu.cs
@@ -73,6 +73,10 @@ namespace Millivolt
 				horiVal /= horizontalMinMaxDifference;
 
 				m_horizontalSensitivitySlider.value = horiVal * 100f;
+
+				// Set timescale again just to override the adjustment of the slider values causing the sensitivity to be set to whatever the slider
+				// is telling it to be
+				GameManager.Instance.SetTimeScale(0);
             }
 
 			/// <summary>


### PR DESCRIPTION
Camera no longer starts moving upon opening the options menu.