### PR TITLE
Gravity UI Fix and Screw Outline

### DIFF
--- a/Assets/GameManager/Scripts/GameManager.cs
+++ b/Assets/GameManager/Scripts/GameManager.cs
@@ -221,7 +221,7 @@ namespace Millivolt
         [ContextMenu("Reset Gravity")]
         public void ResetGravity()
         {
-            ChangeGravity(LevelManager.Instance.levelData.gravityDirection, LevelManager.Instance.levelData.gravityMagnitude);
+            Physics.gravity = Quaternion.Euler(LevelManager.Instance.levelData.gravityDirection) * Vector3.up * LevelManager.Instance.levelData.gravityMagnitude;
         }
     }
 

--- a/Assets/GravityIndicator/GravityIndicatorUI.cs
+++ b/Assets/GravityIndicator/GravityIndicatorUI.cs
@@ -37,6 +37,16 @@ namespace Millivolt
         [SerializeField, Min(0)] private float m_shrinkDuration;
         [SerializeField, Min(0)] private float m_growAndShrinkDelay;
 
+        public void UpdateDirection()
+        {
+            // the game only uses direct world up and direct world down for gravity directions,
+            // so we can just compare the gravity direction with the world up to determine the direction
+            if (Physics.gravity.normalized == Vector3.up)
+                ChangeToUp();
+            else
+                ChangeToDown();
+        }
+
 		public void ChangeToDown()
 		{
             StopAllCoroutines();

--- a/Assets/LevelObjects/PickupObjects/Prefabs/Screw.prefab
+++ b/Assets/LevelObjects/PickupObjects/Prefabs/Screw.prefab
@@ -293,9 +293,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8744595956179460575, guid: 28b6b7ea273fd024aa97be0e3f294df0,
         type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ed90a8e7e43ea0e4f8be8d33219d488e, type: 2}
+    - target: {fileID: 8744595956179460575, guid: 28b6b7ea273fd024aa97be0e3f294df0,
+        type: 3}
       propertyPath: m_Materials.Array.data[1]
       value: 
-      objectReference: {fileID: 2100000, guid: d54a8b06fcfe00d418dd2dab71b1c9d1, type: 2}
+      objectReference: {fileID: 2100000, guid: 71c2342907983ed47a870635570acc58, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28b6b7ea273fd024aa97be0e3f294df0, type: 3}
 --- !u!4 &1039556731905467651 stripped

--- a/Assets/LevelObjects/PickupObjects/Scripts/MeshDissolver.cs
+++ b/Assets/LevelObjects/PickupObjects/Scripts/MeshDissolver.cs
@@ -30,18 +30,18 @@ namespace Millivolt
             // also get the material for the outline/fill shader
             MeshRenderer mesh = GetComponentInChildren<MeshRenderer>();
             Material[] materials = mesh.materials;
-            Material material = new Material(materials[0]);
+            Material dissolveMaterial = new Material(materials[0]);
             Material outlineMaterial = new Material(materials[1]);
 
             // set the new material's shader to the dissolve shader
-            material.shader = m_dissolveShader;
+            dissolveMaterial.shader = m_dissolveShader;
 
             // set the colour of the new material to the colour from the dissolve material
-            material.SetColor("_DissolveColour", m_dissolveColour);
-            material.SetFloat("_DissolveStrength", 0);
+            dissolveMaterial.SetColor("_DissolveColour", m_dissolveColour);
+            dissolveMaterial.SetFloat("_DissolveStrength", 0);
 
             // apply the material
-            mesh.materials = new Material[] { material, outlineMaterial };
+            mesh.materials = new Material[] { dissolveMaterial, outlineMaterial };
 
             // instantiate the particle effect if it exists
             if (m_particle)
@@ -52,8 +52,8 @@ namespace Millivolt
                 StartCoroutine(DisableGravity());
 
             // start the dissolve
-            Tween.ShaderFloat(material, "_DissolveStrength", 0.85f, m_duration, m_delay);
-            Tween.ShaderFloat(outlineMaterial, "_Scale", 0.85f, m_duration, m_delay);
+            Tween.ShaderFloat(dissolveMaterial, "_DissolveStrength", 0.85f, m_duration, m_delay);
+            Tween.ShaderFloat(outlineMaterial, "_Opacity", 0, m_duration, m_delay);
 
             // destroy the object after the delay and total dissolve duration
             Destroy(gameObject, m_delay + m_duration);

--- a/Assets/LevelObjects/PickupObjects/Scripts/PickupObject.cs
+++ b/Assets/LevelObjects/PickupObjects/Scripts/PickupObject.cs
@@ -80,6 +80,10 @@ namespace Millivolt
                         spawnParent.AutoRespawn();
                     }
 
+                    // increase drag for effect
+                    m_rb.drag = 2.3f;
+                    m_rb.angularDrag = 1.2f;
+
                     GetComponent<MeshDissolver>().Dissolve();
                 }
             }

--- a/Assets/Levels/LevelManagement/Scripts/LevelManager.cs
+++ b/Assets/Levels/LevelManagement/Scripts/LevelManager.cs
@@ -86,10 +86,10 @@ namespace Millivolt
 
 			public void SpawnPlayer()
 			{
-				GameManager.Player.Controller.ResetPlayer();
-				GameManager.Player.Model.StopAllCoroutines();
-
                 GameManager.Instance.SetGravity(levelData.gravityDirection, levelData.gravityMagnitude);
+				
+				GameManager.Player.Controller.ResetPlayer();
+				GameManager.Player.Model.ResetModel();
 
 				GameManager.Player.Controller.transform.position = activeCheckpoint.respawnPoint.position;
 				GameManager.Player.Model.SetHeading(activeCheckpoint.frontPosition);

--- a/Assets/Player/Scripts/PlayerModel.cs
+++ b/Assets/Player/Scripts/PlayerModel.cs
@@ -77,20 +77,13 @@ namespace Millivolt
 
             public void OnGravityChange()
             {
-                Vector3 gravityDir = Physics.gravity.normalized;
-
                 // if the gravity indicator is not yet active, then activate it
                 if (!m_gravityIndicatorUI.gameObject.activeSelf)
                     m_gravityIndicatorUI.gameObject.SetActive(true);
 
-                // the game only uses direct world up and direct world down for gravity directions,
-                // so we can just compare the gravity direction with the world up to determine the direction
-                if (gravityDir == Vector3.up)
-                    m_gravityIndicatorUI.ChangeToUp();
-                else
-                    m_gravityIndicatorUI.ChangeToDown();
+                m_gravityIndicatorUI.UpdateDirection();
                 
-                StartCoroutine(RotateWithGravity(-gravityDir));
+                StartCoroutine(RotateWithGravity(-Physics.gravity.normalized));
             }
 
             private IEnumerator RotateWithGravity(Vector3 targetUp)
@@ -121,6 +114,12 @@ namespace Millivolt
             {
                 StopAllCoroutines();
                 transform.rotation = Quaternion.identity;
+            }
+
+            public void ResetModel()
+            {
+                StopAllCoroutines();
+                m_gravityIndicatorUI.UpdateDirection();
             }
         }
     }

--- a/Assets/Shaders/LiamShaders/TestOutline 1.shadergraph
+++ b/Assets/Shaders/LiamShaders/TestOutline 1.shadergraph
@@ -84,20 +84,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "13e075e65e66475482118cf84f0810d8"
-                },
-                "m_SlotId": 2
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "f21615d0e17a45778993074870e6b52a"
-                },
-                "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "5ef8b0f42c464886ad693c9bcc4c9e94"
                 },
                 "m_SlotId": 0
@@ -133,6 +119,20 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "13e075e65e66475482118cf84f0810d8"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "97e6c0aad28a4bd0a36ebb4b305b5741"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "f21615d0e17a45778993074870e6b52a"
                 },
                 "m_SlotId": 0
             }
@@ -833,10 +833,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 70.09251403808594,
-            "y": -67.44749450683594,
-            "width": 0.0,
-            "height": 0.0
+            "x": -10.0,
+            "y": -188.0,
+            "width": 105.0,
+            "height": 34.0
         }
     },
     "m_Slots": [

--- a/Assets/Shaders/LiamShaders/TestOutline1.mat
+++ b/Assets/Shaders/LiamShaders/TestOutline1.mat
@@ -53,5 +53,5 @@ Material:
     - _QueueOffset: 0
     - _Scale: 1.04
     m_Colors:
-    - _Color: {r: 1.7274455, g: 0, b: 0, a: 0}
+    - _Color: {r: 1, g: 1, b: 0, a: 1}
   m_BuildTextureStacks: []


### PR DESCRIPTION
The Gravity Indicator UI now resets to the correct direction when the player respawns after dying. Set up the screw's new outline shader.
The Mesh Dissolver now gets the material for the screw outline and reduces the opacity to 0 as the screw dissolves.