### PR TITLE
Fixed collision issue with magnetron switches and vents

### DIFF
--- a/Assets/LevelObjects/EventObjects/Prefabs/TriggerButton/Trigger Lever.prefab
+++ b/Assets/LevelObjects/EventObjects/Prefabs/TriggerButton/Trigger Lever.prefab
@@ -2940,6 +2940,65 @@ Transform:
   m_Father: {fileID: 2508494280644331978}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: -180, z: -90}
+--- !u!1 &7704430931939348594
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4300159216312905199}
+  - component: {fileID: 9197868712360178799}
+  - component: {fileID: 9038918322811828923}
+  m_Layer: 0
+  m_Name: Collisions
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4300159216312905199
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7704430931939348594}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2508494280644331978}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &9197868712360178799
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7704430931939348594}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.8181178, y: 2.9173694, z: 3.834786}
+  m_Center: {x: 0.48287287, y: 0.39497924, z: -0.91489667}
+--- !u!65 &9038918322811828923
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7704430931939348594}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.21420231, y: 1.5140436, z: 1.3128741}
+  m_Center: {x: -0.05459176, y: 0.39236557, z: -1.8651973}
 --- !u!1 &7978708663647825184
 GameObject:
   m_ObjectHideFlags: 0
@@ -4117,6 +4176,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 212409736027426635, guid: 3e18f9380ca4ec84baba10ca1ff9dc12,
         type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 212409736027426635, guid: 3e18f9380ca4ec84baba10ca1ff9dc12,
+        type: 3}
       propertyPath: m_Center.x
       value: 0.48287287
       objectReference: {fileID: 0}
@@ -4439,7 +4503,7 @@ BoxCollider:
   m_GameObject: {fileID: 2942506925007289140}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Size: {x: 0.21420231, y: 1.5140436, z: 1.3128741}
   m_Center: {x: -0.05459176, y: 0.39236557, z: -1.8651973}
@@ -4570,6 +4634,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: LeverWall
+      objectReference: {fileID: 0}
+    - target: {fileID: 5485469858280559699, guid: 6000143c60cf9b144addaa91e719fce0,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7580783244302254151, guid: 6000143c60cf9b144addaa91e719fce0,
         type: 3}

--- a/Assets/LevelObjects/EventObjects/Scripts/AirVent.cs
+++ b/Assets/LevelObjects/EventObjects/Scripts/AirVent.cs
@@ -29,7 +29,8 @@ namespace Millivolt.LevelObjects.EventObjects
         protected override void OnActivate()
         {
             StartCoroutine(RotateForward());
-
+            //On activation set the objetc layer to ignore so that it wont collide with the player
+            gameObject.layer = LayerMask.NameToLayer("Ignore");
             foreach (GameObject obj in m_objectsToDisable)
             {
                 obj.SetActive(false);


### PR DESCRIPTION
You can now no longer activate the switches in the magnetron while upside down!!!!!. Also fixed air vents by switching them to the ignore layer after they activate to stop the player from getting stuck.