### PR TITLE
Camera updated to ignore see-through objects

### DIFF
--- a/Assets/Camera/Prefabs/CM 3rdPerson Camera.prefab
+++ b/Assets/Camera/Prefabs/CM 3rdPerson Camera.prefab
@@ -243,15 +243,15 @@ MonoBehaviour:
   m_TransparentLayers:
     serializedVersion: 2
     m_Bits: 1024
-  m_MinimumDistanceFromTarget: 0.01
+  m_MinimumDistanceFromTarget: 1
   m_AvoidObstacles: 1
   m_DistanceLimit: 0
   m_MinimumOcclusionTime: 0
-  m_CameraRadius: 0.1
+  m_CameraRadius: 0.9
   m_Strategy: 0
   m_MaximumEffort: 4
-  m_SmoothingTime: 0.1
-  m_Damping: 1
+  m_SmoothingTime: 0
+  m_Damping: 2
   m_DampingWhenOccluded: 0.5
   m_OptimalTargetDistance: 0
 --- !u!114 &2582690241731788639

--- a/Assets/_Scenes/PlayerScene.unity
+++ b/Assets/_Scenes/PlayerScene.unity
@@ -123,6 +123,18 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!134 &150139179
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: DynamicMaterial
+  dynamicFriction: 0
+  staticFriction: 0
+  bounciness: 0
+  frictionCombine: 1
+  bounceCombine: 1
 --- !u!1 &372818521
 GameObject:
   m_ObjectHideFlags: 0
@@ -290,18 +302,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f5b19887c7b941f4bbe839ddf0df3169, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!134 &541169798
-PhysicMaterial:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: DynamicMaterial
-  dynamicFriction: 0
-  staticFriction: 0
-  bounciness: 0
-  frictionCombine: 1
-  bounceCombine: 1
 --- !u!1001 &563426704
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -460,7 +460,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Material
       value: 
-      objectReference: {fileID: 541169798}
+      objectReference: {fileID: 150139179}
     - target: {fileID: 231944331065544993, guid: ff2eab9ba8148954697e7c7ccf1e9783,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
@@ -1259,11 +1259,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: CM 3rdPerson
-      objectReference: {fileID: 0}
-    - target: {fileID: 2582690241731788611, guid: 0b3d3948491a8114e9a077358c03c889,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2582690241731788638, guid: 0b3d3948491a8114e9a077358c03c889,
         type: 3}

--- a/Assets/_Scenes/PlayerScene.unity
+++ b/Assets/_Scenes/PlayerScene.unity
@@ -123,18 +123,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!134 &150139179
-PhysicMaterial:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: DynamicMaterial
-  dynamicFriction: 0
-  staticFriction: 0
-  bounciness: 0
-  frictionCombine: 1
-  bounceCombine: 1
 --- !u!1 &372818521
 GameObject:
   m_ObjectHideFlags: 0
@@ -460,7 +448,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Material
       value: 
-      objectReference: {fileID: 150139179}
+      objectReference: {fileID: 843717940}
     - target: {fileID: 231944331065544993, guid: ff2eab9ba8148954697e7c7ccf1e9783,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
@@ -1250,6 +1238,16 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 867053960}
     m_Modifications:
+    - target: {fileID: 2582690241731788608, guid: 0b3d3948491a8114e9a077358c03c889,
+        type: 3}
+      propertyPath: m_IgnoreTag
+      value: Camera Ignore
+      objectReference: {fileID: 0}
+    - target: {fileID: 2582690241731788608, guid: 0b3d3948491a8114e9a077358c03c889,
+        type: 3}
+      propertyPath: m_TransparentLayers.m_Bits
+      value: 1032
+      objectReference: {fileID: 0}
     - target: {fileID: 2582690241731788609, guid: 0b3d3948491a8114e9a077358c03c889,
         type: 3}
       propertyPath: m_Follow
@@ -1335,6 +1333,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 770836996}
   m_PrefabAsset: {fileID: 0}
+--- !u!134 &843717940
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: DynamicMaterial
+  dynamicFriction: 0
+  staticFriction: 0
+  bounciness: 0
+  frictionCombine: 1
+  bounceCombine: 1
 --- !u!1 &867053959
 GameObject:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -10,6 +10,7 @@ TagManager:
   - Checkpoints
   - Pickup
   - PauseMenu
+  - Camera Ignore
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Went through every collider in the Microwave Scene and added the Camera Ignore tag to them if it seemed right to let the camera pass/see through them.
Set the Ignore Tag on the 3rd Person Cam's Cinemachine Collider component to be the Camera Ignore tag.
Adjusted some values on the 3rd Person Cam to stop it from clipping through walls as often and to feel less stuttery.