### PR TITLE
Footstep particle fix and Credit bg fix

### DIFF
--- a/Assets/Menus/Credits/Scripts/CreditsNamePlayer.cs
+++ b/Assets/Menus/Credits/Scripts/CreditsNamePlayer.cs
@@ -54,13 +54,22 @@ namespace Millivolt.UI
         {
             yield return new WaitForSeconds(person.startDelay + m_initialDelay);
 
+            // Create credit prefab
             GameObject credit = Instantiate(m_creditsPrefab, gameObject.transform);
             credit.transform.position = person.spawnPosition.position;
             CreditsPrefabReferences creditsRef = credit.GetComponent<CreditsPrefabReferences>();
+
+            // Fade in Credit
             Tween.CanvasGroupAlpha(creditsRef.GetComponent<CanvasGroup>(), 1, m_creditNameFadeInTime, 0);
             creditsRef.nameText.text = person.nameText;
             creditsRef.jobText.text = person.jobTitleText;
-            creditsRef.bgImage.sprite = person.bgImage;
+
+            // If there is no bg image then disable the image component on the prefab
+            if (person.bgImage != null)
+                creditsRef.bgImage.sprite = person.bgImage;
+            else
+                creditsRef.bgImage.enabled = false;
+
             if (m_industryMode)
                 creditsRef.quoteText.text = "";
             else
@@ -77,6 +86,7 @@ namespace Millivolt.UI
                 m_playingCredits = false;
             }
 
+            //Fade out credit then destroy after finish
             Tween.CanvasGroupAlpha(creditsRef.GetComponent<CanvasGroup>(), 0, m_creditNameFadeOutTime, 0, null, Tween.LoopType.None, null, () => { DestroyCredit(credit); });
             yield return null;
         }

--- a/Assets/P2.meta
+++ b/Assets/P2.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6ca76060e29a7614594b793c30e357c4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/P2/Art.meta
+++ b/Assets/P2/Art.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e3029d7335637984f9ab40b7d87827ca
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Player/Art/Prefabs/FootStepDust.prefab
+++ b/Assets/Player/Art/Prefabs/FootStepDust.prefab
@@ -44,7 +44,7 @@ ParticleSystem:
   serializedVersion: 8
   lengthInSec: 0.5
   simulationSpeed: 1
-  stopAction: 0
+  stopAction: 2
   cullingMode: 0
   ringBufferMode: 0
   ringBufferLoopRange: {x: 0, y: 1}


### PR DESCRIPTION
Footstep particle now destroys after finishing
Added a check to the image part of the credit creation that stop a giant white box from appearing if theres no bg put in